### PR TITLE
Fix #2. Change update signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,19 @@ keyboardCombos =
 
 init : ( Model, Cmd Msg )
 init =
-    { combos = Keyboard.Combo.init ComboMsg keyboardCombos
-    , content = "Not combo yet"
+    { keys =
+        Keyboard.Combo.init
+            { toMsg = ComboMsg
+            , combos = keyboardCombos
+            }
+    , content = "No combo yet"
     }
         ! []
 
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    Keyboard.Combo.subscriptions model.combos
+    Keyboard.Combo.subscriptions model.keys
 
 
 
@@ -57,7 +61,7 @@ subscriptions model =
 
 
 type alias Model =
-    { combos : Keyboard.Combo.Model Msg
+    { keys : Keyboard.Combo.Model Msg
     , content : String
     }
 
@@ -87,10 +91,10 @@ update msg model =
 
         ComboMsg msg ->
             let
-                updatedCombos =
-                    Keyboard.Combo.update msg model.combos
+                ( keys, cmd ) =
+                    Keyboard.Combo.update msg model.keys
             in
-                { model | combos = updatedCombos } ! []
+                ( { model | keys = keys }, cmd )
 
 
 
@@ -111,5 +115,4 @@ view model =
             , span [] [ text model.content ]
             ]
         ]
-
 ```

--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -77,7 +77,11 @@ update msg model =
             { model | content = "Random Thing" } ! []
 
         ComboMsg msg ->
-            { model | keys = Keyboard.Combo.update msg model.keys } ! []
+            let
+                ( keys, cmd ) =
+                    Keyboard.Combo.update msg model.keys
+            in
+                ( { model | keys = keys }, cmd )
 
 
 

--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -78,10 +78,10 @@ update msg model =
 
         ComboMsg msg ->
             let
-                ( keys, cmd ) =
+                ( updatedKeys, comboCmd ) =
                     Keyboard.Combo.update msg model.keys
             in
-                ( { model | keys = keys }, cmd )
+                ( { model | keys = updatedKeys }, comboCmd )
 
 
 

--- a/src/Keyboard/Combo.elm
+++ b/src/Keyboard/Combo.elm
@@ -221,7 +221,18 @@ type alias Msg =
     Keyboard.Extra.Msg
 
 
-{-| Update the internal model
+{-| Update the internal model. The command should be forwarded by the parent `update`.
+
+    update : Msg -> Model -> ( Model, Cmd Msg )
+    update msg model =
+        case msg of
+            ComboMsg msg ->
+                let
+                    ( updatedKeys, comboCmd ) =
+                        Keyboard.Combo.update msg model.keys
+                in
+                    ( { model | keys = updatedKeys }, comboCmd )
+
 -}
 update : Msg -> Model msg -> ( Model msg, Cmd msg )
 update msg model =


### PR DESCRIPTION
I tried to fix #2 without changing the library's API, but I could not find a way to do it while keeping all of the logic in `subscriptions`. So I moved all of that logic into `update` and changed the signature to

    update : Msg -> Model msg -> ( Model msg, Cmd msg )

Making this change not only let me fix my original bug, but it also made the library way more responsive. In the old code, `subscriptions` is examining the model for keyboard combos before it updates the model with the latest keyboard event. So combo events are delayed by one update cycle. 

I updated the example program. The library is slightly more complicated to use, which is unfortunate. But the change in responsiveness is noticeable.

What do you think? Does this seem like a viable change? I'm happy to make revisions.