### PR TITLE
Prioritize combos by key list length

### DIFF
--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -21,6 +21,7 @@ keyboardCombos =
     , Keyboard.Combo.combo3 ( Keyboard.Combo.control, Keyboard.Combo.alt, Keyboard.Combo.e ) RandomThing
     , Keyboard.Combo.combo1 Keyboard.Combo.j CursorDown
     , Keyboard.Combo.combo2 ( Keyboard.Combo.shift, Keyboard.Combo.j ) JoinLines
+    , Keyboard.Combo.combo3 ( Keyboard.Combo.shift, Keyboard.Combo.alt, Keyboard.Combo.j ) AnotherRandom
     ]
 
 
@@ -59,6 +60,7 @@ type Msg
     = Save
     | SelectAll
     | RandomThing
+    | AnotherRandom
     | CursorDown
     | JoinLines
     | ComboMsg Keyboard.Combo.Msg
@@ -81,6 +83,9 @@ update msg model =
 
         JoinLines ->
             { model | content = "Join Lines" } ! []
+
+        AnotherRandom ->
+            { model | content = "Another Random Thing" } ! []
 
         ComboMsg msg ->
             let
@@ -107,6 +112,7 @@ view model =
         , ul []
             [ li [] [ text "Cursor Down: j" ]
             , li [] [ text "Join lines: shift+j" ]
+            , li [] [ text "Another Random: alt+shift+j" ]
             ]
         , div []
             [ strong [] [ text "Current command: " ]

--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -19,6 +19,8 @@ keyboardCombos =
     [ Keyboard.Combo.combo2 ( Keyboard.Combo.control, Keyboard.Combo.s ) Save
     , Keyboard.Combo.combo2 ( Keyboard.Combo.control, Keyboard.Combo.a ) SelectAll
     , Keyboard.Combo.combo3 ( Keyboard.Combo.control, Keyboard.Combo.alt, Keyboard.Combo.e ) RandomThing
+    , Keyboard.Combo.combo1 Keyboard.Combo.j CursorDown
+    , Keyboard.Combo.combo2 ( Keyboard.Combo.shift, Keyboard.Combo.j ) JoinLines
     ]
 
 
@@ -57,6 +59,8 @@ type Msg
     = Save
     | SelectAll
     | RandomThing
+    | CursorDown
+    | JoinLines
     | ComboMsg Keyboard.Combo.Msg
 
 
@@ -72,12 +76,18 @@ update msg model =
         RandomThing ->
             { model | content = "Random Thing" } ! []
 
+        CursorDown ->
+            { model | content = "Cursor Down" } ! []
+
+        JoinLines ->
+            { model | content = "Join Lines" } ! []
+
         ComboMsg msg ->
             let
                 ( updatedKeys, comboCmd ) =
                     Keyboard.Combo.update msg model.combos
             in
-            ( { model | combos = updatedKeys }, comboCmd )
+                ( { model | combos = updatedKeys }, comboCmd )
 
 
 
@@ -92,6 +102,11 @@ view model =
             [ li [] [ text "Save: Ctrl+s" ]
             , li [] [ text "Select All: Ctrl+a" ]
             , li [] [ text "Random Thing: Ctrl+Alt+e" ]
+            ]
+        , h1 [] [ text "Vim:" ]
+        , ul []
+            [ li [] [ text "Cursor Down: j" ]
+            , li [] [ text "Join lines: shift+j" ]
             ]
         , div []
             [ strong [] [ text "Current command: " ]

--- a/src/Keyboard/Combo.elm
+++ b/src/Keyboard/Combo.elm
@@ -742,15 +742,41 @@ performComboTask combo =
 
 
 arePressed : Keyboard.Extra.State -> List Key -> Bool
-arePressed keyTracker keysPressed =
+arePressed keyState combo =
     List.all
-        (\key -> Keyboard.Extra.isPressed key keyTracker)
-        keysPressed
+        (\key -> Keyboard.Extra.isPressed key keyState)
+        combo
+
+
+{-| Order the combos so the ones with the most keys come before
+-- ones with the least keys; that way combos like "shift+j" are
+-- prioritized over "j"
+-}
+prioritizeCombos : List (KeyCombo msg) -> List (KeyCombo msg)
+prioritizeCombos combos =
+    List.sortWith
+        (\a b ->
+            let
+                keyListLength c =
+                    List.length (keyList c)
+            in
+                case compare (keyListLength a) (keyListLength b) of
+                    LT ->
+                        GT
+
+                    EQ ->
+                        EQ
+
+                    GT ->
+                        LT
+        )
+        combos
 
 
 matchesCombo : Model msg -> Maybe (KeyCombo msg)
 matchesCombo model =
-    find (\combo -> arePressed model.keys <| keyList combo) model.combos
+    prioritizeCombos model.combos
+        |> find (\combo -> arePressed model.keys (keyList combo))
 
 
 keyList : KeyCombo msg -> List Key


### PR DESCRIPTION
Currently `j` and `shift+j` will resolve to FIFO resolution (meaning if you specify `j` first, then `shift+j` will always resolve to `j`). Changing this to check the longest combos first.