### PR TITLE
Get latest version into master

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.0.0",
+    "version": "5.0.0",
     "summary": "Handle keyboard key combinations with type safety in Elm",
     "repository": "https://github.com/scottcorgan/keyboard-combo.git",
     "license": "BSD3",


### PR DESCRIPTION
I just cherry-picked the `5.0.0` tag into master to get the latest version into master. But in order to publish the fix in #6, we'd probably need to bump the version and publish. That should get everything back in-line again. This should fix #7.